### PR TITLE
Quick fix: compilation error, boolean macros

### DIFF
--- a/Myers/VGPpair.c
+++ b/Myers/VGPpair.c
@@ -10,6 +10,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdbool.h>
 #include <string.h>
 #include <stdint.h>
 #include <ctype.h>
@@ -270,7 +271,7 @@ int main(int argc, char *argv[])
 
       HAS_QVS = (v1->info['Q']->given.count > 0);
 
-      vf = oneFileOpenWriteNew("-",schema,"irp",TRUE,NTHREADS);
+      vf = oneFileOpenWriteNew("-",schema,"irp",true, NTHREADS);
 
       oneInheritProvenance(vf,v1);
       oneInheritProvenance(vf,v2);

--- a/VGP/VGPpair.c
+++ b/VGP/VGPpair.c
@@ -10,6 +10,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdbool.h>
 #include <string.h>
 #include <stdint.h>
 #include <ctype.h>
@@ -270,7 +271,7 @@ int main(int argc, char *argv[])
 
       HAS_QVS = (v1->info['Q']->given.count > 0);
 
-      vf = oneFileOpenWriteNew("-",schema,"irp",TRUE,NTHREADS);
+      vf = oneFileOpenWriteNew("-",schema,"irp",true,NTHREADS);
 
       oneInheritProvenance(vf,v1);
       oneInheritProvenance(vf,v2);


### PR DESCRIPTION
Currently the code doesn't compile:


```
VGPpair.c:273:49: error: use of undeclared identifier 'TRUE'
      vf = oneFileOpenWriteNew("-",schema,"irp",TRUE,NTHREADS);
                                                ^
1 error generated.
make[1]: *** [VGPpair] Error 1
make: *** [all] Error 2

```

The reason is `VGPpair.c` used to contain `#include "../Durbin/VGPlib.h"`, which defined

```
static const int TRUE  = 1;
static const int FALSE = 0;
```

Elsewhere in the code there are macro definitions for 

```
#define TRUE  1
#define FALSE 0
```

Given the header `stdbool.h` contains these exact macros, we could use them---it was introduced in C99, as Gene mentions. I'll try to make this change elsewhere.